### PR TITLE
Update fstab.qcom

### DIFF
--- a/init/fstab.qcom
+++ b/init/fstab.qcom
@@ -8,8 +8,8 @@ system_ext                                   /system_ext             ext4    ro,
 product                                      /product                ext4    ro,barrier=1,discard                                                                              wait,logical,first_stage_mount
 vendor                                       /vendor                 ext4    ro,barrier=1,discard                                                                              wait,logical,first_stage_mount
 odm                                          /odm                    ext4    ro,barrier=1,discard                                                                              wait,logical,first_stage_mount
-/dev/block/bootdevice/by-name/userdata       /data                   ext4    noatime,nosuid,nodev,barrier=0,noauto_da_alloc                                                    latemount,wait,check,fileencryption=ice,quota
-/dev/block/bootdevice/by-name/userdata       /data                   f2fs    noatime,nosuid,nodev,discard,background_gc=off,fsync_mode=nobarrier                               latemount,wait,check,fileencryption=ice,quota
+/dev/block/bootdevice/by-name/userdata       /data                   ext4    noatime,nosuid,nodev,barrier=0,noauto_da_alloc                                                    latemount,wait,check,encryptable=ice,quota
+/dev/block/bootdevice/by-name/userdata       /data                   f2fs    noatime,nosuid,nodev,discard,nobarrier,fsync_mode=nobarrier                                       latemount,wait,check,encryptable=ice,quota
 /dev/block/bootdevice/by-name/modem          /vendor/firmware_mnt    vfat    ro,shortname=lower,uid=0,gid=1000,dmask=227,fmask=337,context=u:object_r:firmware_file:s0         wait
 /dev/block/bootdevice/by-name/dsp            /vendor/dsp             ext4    ro,nosuid,nodev,barrier=1                                                                         wait
 /dev/block/bootdevice/by-name/persist        /mnt/vendor/persist     ext4    noatime,nosuid,nodev,barrier=1                                                                    wait


### PR DESCRIPTION
let F2FS background garbage collector automatic, instead of off ,and add nobarrier option
change fileencryption to encryptable for optional encryption, and no encryption by default (faster filesystem)

After rom flash, use custom recovery like orangefox to format /data as F2FS instead of ext4